### PR TITLE
Sync main with develop

### DIFF
--- a/.claude/commands/bdd-in-issue.md
+++ b/.claude/commands/bdd-in-issue.md
@@ -1,0 +1,80 @@
+<!--
+File path in your repo:
+   .claude/commands/bdd-in-issue.md     (Claude Code)
+or .github/prompts/bdd-in-issue.prompt  (GitHub Copilot prompt files)
+
+Invocation:
+   /bdd-in-issue 1247                  ← GitHub issue number
+   /bdd-in-issue issues/03-ui-modal.md ← local Pocock-style issue file
+-->
+
+---
+name: bdd-in-issue
+description: Generate Given-When-Then scenarios for an issue and append
+             them to the issue body, ready for the Copilot agent.
+allowed-tools: Read, Bash(gh issue view *), Edit, Bash(gh issue edit *)
+---
+
+# bdd-in-issue
+
+Read the issue body for `$ARGUMENTS`.
+
+- If `$ARGUMENTS` is a number → fetch with `gh issue view $ARGUMENTS --json title,body`
+- If `$ARGUMENTS` is a path → read the local file directly
+
+Then:
+
+1. **Identify the user-facing behaviour** the issue describes. If unclear, stop and list the missing pieces in an "Unresolved questions" section. Do not invent.
+
+2. **Generate 3–5 BDD scenarios** in Gherkin, covering:
+   - 1× happy path (the core behaviour)
+   - 1–2× edge cases (empty input, validation failure, boundary)
+   - 1× authorisation / stop-rule (the user-without-permission case, OR the AGENTS.md stop rule that protects this area)
+
+3. **Use the project's domain vocabulary** — read `UBIQUITOUS_LANGUAGE.md` if it exists. Don't introduce synonyms.
+
+4. **Append to the issue body** under a `## BDD scenarios` heading. Do not overwrite existing sections.
+   - GitHub: `gh issue edit $ARGUMENTS --body-file -`
+   - Local: append to the file
+
+5. **End with `## Unresolved questions`** if there are any. Empty this section if none.
+
+## Constraints
+
+- Do **not** implement anything. Scenarios only.
+- Keep each scenario ≤ 10 lines. If it's longer, it's two scenarios.
+- Use the project's BDD framework conventions (SpecFlow / Cucumber / xUnit + Gherkin) — read `AGENTS.md` for the convention.
+- One Feature per file. One Scenario per behaviour.
+
+## Example output to append
+
+```gherkin
+## BDD scenarios
+
+Feature: Split-even share mode
+
+  Scenario: Manager splits a 4-person check evenly
+    Given a check "1247" totalling 800 SEK with 4 diners
+    When the cashier clicks "Split evenly"
+    Then 4 share rows are created in split_shares
+    And each share equals 200 SEK
+
+  Scenario: Empty diner list rejects the split
+    Given a check with 0 diners assigned
+    When the cashier clicks "Split evenly"
+    Then a validation error is shown
+    And no share rows are created
+
+  Scenario: Audit trail records who initiated the split
+    Given I am logged in as cashier "alex"
+    When I confirm a split-even on check "1247"
+    Then split_shares rows are stamped with created_by = "alex"
+```
+
+---
+
+## Source
+
+Inspired by Matt Pocock's `to-issues` and `tdd` skills (mattpocock/skills, Apache-2.0)
+combined with Carlos Granados' BDD-with-AI workflow.
+Adapted for Caspeco's Jira ↔ GitHub Copilot agent flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@ See `docs/architectural_patterns.md` for:
 - Voice tool handlers MUST call `clearAllHighlights()` before navigating — see `src/app/page.tsx:28-31`.
 - Linters handle code style (`next lint`, `tsc --noEmit`) — don't restate style rules here.
 
+## Issue conventions
+
+Every issue in this project MUST include BDD scenarios (`Given` / `When` / `Then`) covering the acceptance criteria. The BDD block is the contract: when an agent picks the issue up, it derives TDD test cases directly from the scenarios. No BDD → the issue is not ready for an agent to pick up — apply `needs-info` and stop.
+
 ## Agent harness
 
 - **Issue tracker** — GitHub issues on `phassle/Demo20260504` via `gh` CLI. See `docs/agents/issue-tracker.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,38 @@
+# caspeco-fe-demo
+
+A demo POS for restaurants. Mocked data, no backend, no auth. The shopping surface that an agent works in is the open POS order draft — there is no concept of physical tables in this demo.
+
+## Language
+
+**Order**:
+A draft of items being assembled at the till before payment. Held entirely in client state.
+_Avoid_: Cart, basket, ticket, check
+
+**Order Item**:
+A single product row inside an Order. See `caspeco-fe-demo/src/components/pos/OrderPanel.tsx:5-9`.
+_Avoid_: Line, line item
+
+**Order Note** *(new)*:
+A free-text annotation attached to the currently-open Order. Cleared when the Order is paid or reset.
+_Avoid_: Bordsnotering (see Flagged ambiguities), comment, memo, label
+
+**Dine-in / Take-away**:
+A boolean toggle on the Order that sets fulfilment mode. There is no follow-on workflow tied to this — it's display state only.
+
+**Pay**:
+Terminal state of an Order. Triggers `onPay` (`OrderPanel.tsx:32-39`), which resets the draft. There is no payment-processing layer.
+
+## Relationships
+
+- An **Order** has zero or many **Order Items**.
+- An **Order** has zero or one **Order Note**.
+- **Pay** ends the lifecycle of an **Order** (and its **Order Note**).
+
+## Example dialogue
+
+> **Dev:** "When the cashier presses Pay, what happens to the **Order Note**?"
+> **Domain expert:** "Same as the items — gone. The next **Order** starts blank. Notes are situational, not historical."
+
+## Flagged ambiguities
+
+- **"Bordsnotering" vs "Order Note"** — The originating slack thread (`slack-thread.md`) frames the feature as a *table* note tied to a floor plan and a `booking.status` lifecycle. Neither tables nor individual bookings exist in this demo. Resolved: the feature is implemented as an **Order Note** on the POS order draft. The "vänd bord"-question collapses into the natural Order lifecycle (Pay = end). The permissions question collapses into N/A (demo has no auth). Anything that genuinely needs a *table* abstraction is out of scope and tracked separately if surfaced.

--- a/slack-thread-v2.md
+++ b/slack-thread-v2.md
@@ -1,0 +1,85 @@
+# Slack-tråd: "Slut just nu"-markering på produkter (POS)
+
+**Kanal:** `#produkt-caspeco-fe`
+**Datum:** 2026-05-09
+**Deltagare:** Anna Lindqvist (PM), Erik Dahlberg (Tech Lead), Sofia Berg (UX), Marcus Nilsson (CS), Lina Holm (kund — Restaurang Stensjö)
+
+---
+
+**Anna Lindqvist** *09:14*
+Andra tråden den här veckan 👋. Lina + två andra kunder rapporterade samma sak igår: serveringspersonalen tog emot beställningar på rätter som var slut, realiserade det först när köket sa *"nej det har vi inte"*, och fick gå tillbaka till gästen och be om ursäkt. Halva poängen med en POS är väl att den ska *veta*. Skissar på en "slut just nu"-markering på produkter — knapp för servitören → produkten greyas ut i ProductGrid. Tankar?
+
+**Lina Holm** *09:16*
+Vi har det här hela tiden. Speciellt fredagskvällar när populära rätter tar slut. Köket meddelar baren via en WhatsApp-grupp ibland och servitörerna får informationen en halvtimme senare. Har hänt att vi sålt fyra portioner av samma rätt efter att den var slut.
+
+**Erik Dahlberg** *09:22*
+Lättaste tekniska skissen: lägg till `available: boolean` på `Product`, default `true`. ProductGrid renderar greyed-out + "Slut"-badge när `false`. Hur sätter man den `false`? En "..."-meny på produktkortet med *"Markera som slut just nu"*?
+
+**Sofia Berg** *09:25*
+Tänk igenom innan vi spikar UI:t:
+1. Vem får markera — vem som helst eller bara hovmästare/manager?
+2. Hur länge gäller markeringen? Resten av passet? Hela dagen? Tills nästa morgon?
+3. Återställning — manuell toggle eller auto-reset vid något event?
+4. Vad händer om servitören klickar på en markerad produkt ändå? Helt disablad eller varning ("vill du ändå sälja?")?
+5. Påverkar det sökningen i `SearchField`?
+
+**Marcus Nilsson** *09:31*
+Från support-ärenden ser jag två tydliga mönster:
+(a) *"vissa produkter är slut idag"* — auto-reset nästa morgon
+(b) *"den här produkten har vi inte just nu (10–15 min)"* — kort-livad, kommer tillbaka inom passet
+Cirka 90 % av fallen är (a) tror jag.
+
+**Anna Lindqvist** *09:34*
+Min instinkt: gäller för dagen, auto-reset vid midnatt eller vid nästa morgonpasses start. Manuell undo om servitören klickade fel eller om en ny leverans kommer in mitt i passet.
+
+**Lina Holm** *09:38*
+Funkar för oss. Men kan en produkt **bli tillgänglig igen mitt under passet** utan att man måste vänta till imorgon? Vi har scenariot — t.ex. en leverans kommer 17:30 och då vill vi inte sälja under "slut" till midnatt.
+
+**Erik Dahlberg** *09:41*
+Då måste vi avgöra två frågor som hänger ihop:
+- **Lagring**: lokal state per session (försvinner vid refresh) eller persisteras nånstans?
+- **Synk mellan terminaler**: om lokalen har två kassor — ska "slut" på terminal 1 reflekteras på terminal 2 direkt?
+Helt olika storlek på arbetet.
+
+**Sofia Berg** *09:44*
+Och visuellt — bara `opacity: 0.4` + en liten badge är minimalistiskt men det är lätt att glömma bort vad som markerats. Vi kanske vill ha en räknare i headern (*"5 slut just nu"*) eller en mini-lista? Eller ingenting?
+
+**Marcus Nilsson** *09:48*
+En kund (Bistro Lyran) frågade också om man kan markera en hel **kategori** som slut — t.ex. *"vi har inga sushi-rätter alls just nu"*. Skulle ge ett ✗ på CategoryPills. Tror per-produkt räcker för v1, men nämner det.
+
+**Anna Lindqvist** *09:52*
+Håller med, kategori-flag är v2.
+
+OK frågor jag tar med mig:
+- Behörighet för markering
+- Lagrings-modell (lokal vs. delad)
+- Auto-reset-trigger
+- Klick på markerad produkt — disable eller varning?
+- Sökning — gömma eller visa med badge?
+- UI för översikt (räknare? lista? inget?)
+- Hur återställer man manuellt?
+
+Erik, kan du sikta på början av nästa vecka? Är osäker på hur stor diskussionen om persistens blir.
+
+**Erik Dahlberg** *09:55*
+Beror helt på vad ni svarar på persistens-frågan. Rent lokal-state = 1–2 timmar. Delat mellan terminaler = ny endpoint + sync-mekanism. Faktor 5x i scope.
+
+**Sofia Berg** *09:58*
+Skickar wireframe på greyed-out-tillståndet och en variant med räknare i headern. Också en med litet "✓ Tillbaka i sortimentet"-affordans när man av-markerar.
+
+**Anna Lindqvist** *10:02*
+👍 Drar ihop till en grilling-session. Lägger PRD-utkast i kommentarerna när jag har en första version.
+
+---
+
+## Sammanfattning av öppna frågor
+
+- **Behörighet** — alla servitörer eller bara manager-rollen?
+- **Lagrings-modell** — lokal page-state eller delad mellan terminaler?
+- **Auto-reset-trigger** — midnatt? skiftslut? "x timmar efter markering"? aldrig (manuell-only)?
+- **Klick på markerad produkt** — disable helt eller varningsdialog?
+- **Sökning** — gömma slutmarkerade eller visa dem med badge i resultaten?
+- **Översikts-UI** — räknare i headern, separat lista, eller ingenting alls?
+- **Manuell återställning** — inline toggle på produkten eller en management-vy?
+- **Kategori-markering** — uttryckligen utanför scope (v2).
+- **Tillbaka-i-sortimentet-flow** — separata UI-states för "markera slut" vs "markera tillbaka", eller samma toggle?


### PR DESCRIPTION
Brings `main` up to date with `develop`.

## Summary
- CONTEXT.md added
- BDD issue convention documented in AGENTS.md
- Second slack-thread demo seed (`slack-thread-v2.md`)
- `/bdd-in-issue` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)